### PR TITLE
[Unit-tests] Fix test framework by telling sqldb to manage handles so…

### DIFF
--- a/src/include/test/switch_test.h
+++ b/src/include/test/switch_test.h
@@ -113,7 +113,7 @@ static switch_status_t fst_init_core_and_modload(const char *confdir, const char
 	switch_core_set_globals();
 
 	if (!minimal) {
-		status = switch_core_init_and_modload(0, SWITCH_TRUE, &err);
+		status = switch_core_init_and_modload(SCF_USE_SQL, SWITCH_TRUE, &err);
 		switch_sleep(1 * 1000000);
 		switch_core_set_variable("sound_prefix", "." SWITCH_PATH_SEPARATOR);
 		if (status != SWITCH_STATUS_SUCCESS && err) {


### PR DESCRIPTION
… they don't leak and are destroyed on shutdown.